### PR TITLE
Temporarily downgrade a dependent gem version

### DIFF
--- a/google_drive.gemspec
+++ b/google_drive.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency("nokogiri", [">= 1.4.4", "!= 1.5.1", "!= 1.5.2"])
   s.add_dependency("oauth", [">= 0.3.6"])
   s.add_dependency("oauth2", [">= 0.5.0"])
-  s.add_dependency("google-api-client", [">= 0.7.0"])
+  s.add_dependency("google-api-client", [">= 0.6.3"])
   s.add_development_dependency("rake", [">= 0.8.0"])
 
 end

--- a/google_drive.gemspec
+++ b/google_drive.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name = "google_drive"
-  s.version = "0.3.11"
+  s.version = "0.3.11.1"
   s.authors = ["Hiroshi Ichikawa"]
   s.email = ["gimite+github@gmail.com"]
   s.summary = "A library to read/write files/spreadsheets in Google Drive/Docs."


### PR DESCRIPTION
faradayのバージョン依存解決のため、一時的にgoogle-api-clientのバージョンを下げる。
google-api-clientは0.7からfaraday 0.9に依存する。
google-drive-rubyは0.3.10からDrive APIに移行している。また、1.0.0ではgoogle-api-client 0.7のメソッドを使用している。

CFO-Alphaに[OAuth2対応](https://github.com/C-FO/CFO-Alpha/pull/11852)を当てたローカル環境で、faraday 0.8.9, google-api-client 0..6.4と共に動作確認済み。

Asana: https://app.asana.com/0/7959229720997/31589153744465